### PR TITLE
Fix crates.io shield link

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This library is an implementation of **zero-cost futures** in Rust.
 
 [![Build Status](https://travis-ci.org/alexcrichton/futures-rs.svg?branch=master)](https://travis-ci.org/alexcrichton/futures-rs)
 [![Build status](https://ci.appveyor.com/api/projects/status/yl5w3ittk4kggfsh?svg=true)](https://ci.appveyor.com/project/alexcrichton/futures-rs)
-[![Crates.io](https://img.shields.io/crates/v/futures.svg?maxAge=2592000)]()
+[![Crates.io](https://img.shields.io/crates/v/futures.svg?maxAge=2592000)](https://crates.io/crates/futures)
 
 [Documentation](https://docs.rs/futures)
 


### PR DESCRIPTION
The url for the crates.io shield wasn't set. Fixed it to point at https://crates.io/crates/futures